### PR TITLE
Added implmentation to Debugger class. Added exception types

### DIFF
--- a/Debugger.cpp
+++ b/Debugger.cpp
@@ -1,0 +1,30 @@
+#include "Debugger.hpp"
+
+namespace lws {
+namespace dbg {
+
+Debugger::Debugger(const std::string& _originCls, DebugLevel _default=DebugLevel::MEDIUM, std::ostream& _output, std::ostream& _erroutput=std::cerr) {
+    originCls = _originCls;
+    defLevel = _default;
+    outputStream = &_output; // we have to indirectly use pointers, as the copy constructor via operator= is protected.
+    errStream = &_erroutput;
+    if(!outputStream || outputStream->bad() || !errStream || errStream->bad()) {
+        throw err::BadStream();
+    }
+}
+
+#ifdef DEBUG // The actual implementation; we only want these if the user wants to debug.
+
+#else
+
+#endif
+
+}
+namespace err {
+
+const char* BadStream::what() const _GLIBCXX_TXN_SAFE_DYN _GLIBCXX_NOTHROW {
+    return "Could not open output stream!"; // FIXME: Not verbose enough (ironic)
+}
+
+}
+}

--- a/Debugger.hpp
+++ b/Debugger.hpp
@@ -1,9 +1,12 @@
+// Ensure this file is only included once
 #pragma once
 #ifndef _LWS_DEBUGGER_
 #define _LWS_DEBUGGER_
 #include <iostream>
 #include <fstream>
 #include <string>
+namespace lws {
+namespace dbg {
 class Debugger {
 	public:
 		enum DebugLevel { // Allows us to know how verbose a debug statement is.
@@ -11,19 +14,27 @@ class Debugger {
 			MEDIUM,
 			HIGH
 		};
-		Debugger();
 		Debugger(const std::string& _originCls, 
 				DebugLevel _default=DebugLevel::MEDIUM,
-				std::ostream& _output=std::cout);
-		Debugger();
+				std::ostream& _stdoutput=std::cout,
+				std::ostream& _erroutput=std::cerr);
 		std::ostream& operator<<(const std::string& msg);
 		std::ostream& operator<<(const char* msg);
 		std::ostream& operator<<(const int& msg);
 		std::ostream& operator<<(const double& msg);
 		std::ostream& operator<<(const float& msg);
-		std::ostream& operator<<(ostream& os);
-	private:
-		DebugLevel defaultLevel;
+		std::ostream& operator<<(std::ostream& os);
+	protected: // use protected instead of private; if the user wants to inherit from this and change our state, fine by me.
+		DebugLevel defLevel;
 		std::string originCls;
+		static std::ostream* outputStream; // we want this staic, so everything gets written to a specific place.
+		static std::ostream* errStream;
 };
+}
+namespace err { // custom errors
+struct BadStream : public std::exception {
+	const char* what() const _GLIBCXX_TXN_SAFE_DYN _GLIBCXX_NOTHROW override;
+};
+}
+}
 #endif


### PR DESCRIPTION
Removed deconstruct; closing the file will be the user's job. Maybe add another constructor that specifically takes in std::ofstreams?

Also added a spot for custom exceptions. As we need more exceptions, they shall continue to be defined. Maybe move those to their own file, though.